### PR TITLE
fix: re-throw if rpc terminates prematurely

### DIFF
--- a/src/hooks/tap-error-to-log-message.ts
+++ b/src/hooks/tap-error-to-log-message.ts
@@ -37,6 +37,8 @@ function tapErrorToLogMessage(
           )
         );
       }
+      // Ensure webpack exits instead of continuing compilation despite issues checking prematurely exiting
+      throw error;
     }
   });
 }


### PR DESCRIPTION
If the issue checking service runs out of memory, webpack will continue compilation as if it had passed successfully - this can cause CI to pass on a broken build. The PR ensures we re-throw the RPC error so webpack is aware of the failure and can halt compilation.